### PR TITLE
ci: allow actions/checkout to run on forks

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,7 +26,6 @@ jobs:
           repository: supportpal/language-files
           path: en/
           ref: master
-          token: ${{ secrets.GH_TOKEN }}
 
       - name: Install dependencies
         run: composer require --dev supportpal/language-tools


### PR DESCRIPTION
The workflow currently errors when ran on PRs generated by forks:
```
Error: Input required and not supplied: token
```

This is due to changes in https://github.blog/changelog/2021-02-19-github-actions-workflows-triggered-by-dependabot-prs-will-run-with-read-only-permissions/ which `${{ secrets.??? }}` are not available on workflows generated by forks.