### PR TITLE
ci: change pt_BR to pt-BR

### DIFF
--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -11,7 +11,7 @@ jobs:
 
     strategy:
       matrix:
-        branch: ['de', 'es', 'fa', 'fr', 'nl', 'pl', 'pt_BR', 'rs', 'ru', 'sv', 'tr']
+        branch: ['de', 'es', 'fa', 'fr', 'nl', 'pl', 'pt-BR', 'rs', 'ru', 'sv', 'tr']
         path: ['614ed54b-7b88-4936-a3a2-e1a84669010a']
 
     steps:


### PR DESCRIPTION
`pt_BR` doesn't conform to BCP 47 https://en.wikipedia.org/wiki/IETF_language_tag