### PR TITLE
Fix translation for "slower"

### DIFF
--- a/general.php
+++ b/general.php
@@ -390,7 +390,7 @@ return array(
      */
     "appearance"                => "Apparance",
     "faster"                    => "Plus vite",
-    "slower"                    => "Plus douvement",
+    "slower"                    => "Plus lent",
     "revoke"                    => "Revoquer",
     "configure"                 => "Configurer",
 


### PR DESCRIPTION
The translation have been modified for *lent*.

The word *douvement* does not exists in french. I suspect a typo and should have been *doucement*, however it would not be the appropriate translation for *slower* in this context. 